### PR TITLE
Consider passing context as an input argument to manage concurrent operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Updated
+
+- Considered passing context as an input argument to manage concurrent operations (control cancellation, set timeouts/deadlines, propagate values).
+
 ## [0.2.0] - 14-01-2025
 
 ### Updated

--- a/cmd/crypto-vault-grpc-service/crypto_vault_service.go
+++ b/cmd/crypto-vault-grpc-service/crypto_vault_service.go
@@ -103,12 +103,13 @@ func main() {
 		log.Fatalf("Error creating crypto key repository instance: %v", err)
 	}
 
-	blobConnector, err := connector.NewAzureBlobConnector(&config.BlobConnector, logger)
+	ctx := context.Background()
+	blobConnector, err := connector.NewAzureBlobConnector(ctx, &config.BlobConnector, logger)
 	if err != nil {
 		log.Fatalf("%v", err)
 	}
 
-	vaultConnector, err := connector.NewAzureVaultConnector(&config.KeyConnector, logger)
+	vaultConnector, err := connector.NewAzureVaultConnector(ctx, &config.KeyConnector, logger)
 	if err != nil {
 		log.Fatalf("%v", err)
 	}

--- a/cmd/crypto-vault-rest-service/crypto_vault_service.go
+++ b/cmd/crypto-vault-rest-service/crypto_vault_service.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	v1 "crypto_vault_service/internal/api/rest/v1"
 	"crypto_vault_service/internal/app/services"
 	"crypto_vault_service/internal/domain/blobs"
@@ -131,9 +132,10 @@ func main() {
 		log.Fatalf("Error creating crypto key repository instance: %v", err)
 	}
 
+	ctx := context.Background()
 	var blobConnector connector.BlobConnector
 	if config.BlobConnector.CloudProvider == "azure" {
-		blobConnector, err = connector.NewAzureBlobConnector(&config.BlobConnector, logger)
+		blobConnector, err = connector.NewAzureBlobConnector(ctx, &config.BlobConnector, logger)
 		if err != nil {
 			log.Fatalf("%v", err)
 			return
@@ -142,7 +144,7 @@ func main() {
 
 	var vaultConnector connector.VaultConnector
 	if config.BlobConnector.CloudProvider == "azure" {
-		vaultConnector, err = connector.NewAzureVaultConnector(&config.KeyConnector, logger)
+		vaultConnector, err = connector.NewAzureVaultConnector(ctx, &config.KeyConnector, logger)
 		if err != nil {
 			log.Fatalf("%v", err)
 			return

--- a/internal/api/grpc/v1/server.go
+++ b/internal/api/grpc/v1/server.go
@@ -77,7 +77,7 @@ func (s BlobUploadServer) Upload(req *pb.BlobUploadRequest, stream pb.BlobUpload
 		return fmt.Errorf("%v", err)
 	}
 
-	blobMetas, err := s.blobUploadService.Upload(form, userId, encryptionKeyId, signKeyId)
+	blobMetas, err := s.blobUploadService.Upload(stream.Context(), form, userId, encryptionKeyId, signKeyId)
 	if err != nil {
 		return fmt.Errorf("failed to upload blob: %v", err)
 	}
@@ -125,7 +125,7 @@ func (s *BlobDownloadServer) DownloadById(req *pb.BlobDownloadRequest, stream pb
 		decryptionKeyId = &req.DecryptionKeyId
 	}
 
-	bytes, err := s.blobDownloadService.Download(id, decryptionKeyId)
+	bytes, err := s.blobDownloadService.Download(stream.Context(), id, decryptionKeyId)
 	if err != nil {
 		return fmt.Errorf("could not download blob with id %s: %v", id, err)
 	}
@@ -242,7 +242,7 @@ func (s *BlobMetadataServer) GetMetadataById(ctx context.Context, req *pb.IdRequ
 
 // DeleteById handles the DELETE request to delete a blob by its ID
 func (s *BlobMetadataServer) DeleteById(ctx context.Context, req *pb.IdRequest) (*pb.InfoResponse, error) {
-	err := s.blobMetadataService.DeleteByID(req.Id)
+	err := s.blobMetadataService.DeleteByID(ctx, req.Id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to delete blob: %v", err)
 	}
@@ -262,7 +262,8 @@ func NewCryptoKeyUploadServer(cryptoKeyUploadService *services.CryptoKeyUploadSe
 // UploadKeys generates and uploads cryptographic keys
 func (s *CryptoKeyUploadServer) Upload(req *pb.UploadKeyRequest, stream pb.CryptoKeyUpload_UploadServer) error {
 	userId := uuid.New().String() // TBD: extract user id from JWT
-	cryptoKeyMetas, err := s.cryptoKeyUploadService.Upload(userId, req.Algorithm, uint(req.KeySize))
+
+	cryptoKeyMetas, err := s.cryptoKeyUploadService.Upload(stream.Context(), userId, req.Algorithm, uint(req.KeySize))
 	if err != nil {
 		return fmt.Errorf("failed to generate and upload crypto keys: %v", err)
 	}
@@ -295,7 +296,7 @@ func NewCryptoKeyDownloadServer(cryptoKeyDownloadService *services.CryptoKeyDown
 
 // DownloadById downloads a key by its ID
 func (s *CryptoKeyDownloadServer) DownloadById(req *pb.KeyDownloadRequest, stream pb.CryptoKeyDownload_DownloadByIdServer) error {
-	bytes, err := s.cryptoKeyDownloadService.Download(req.Id)
+	bytes, err := s.cryptoKeyDownloadService.Download(stream.Context(), req.Id)
 	if err != nil {
 		return fmt.Errorf("failed to download crypto key: %v", err)
 	}
@@ -393,7 +394,7 @@ func (s *CryptoKeyMetadataServer) GetMetadataById(ctx context.Context, req *pb.I
 
 // DeleteById deletes a key by its ID
 func (s *CryptoKeyMetadataServer) DeleteById(ctx context.Context, req *pb.IdRequest) (*pb.InfoResponse, error) {
-	err := s.cryptoKeyMetadataService.DeleteByID(req.Id)
+	err := s.cryptoKeyMetadataService.DeleteByID(ctx, req.Id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to delete crypto key: %v", err)
 	}

--- a/internal/domain/blobs/contracts.go
+++ b/internal/domain/blobs/contracts.go
@@ -1,12 +1,15 @@
 package blobs
 
-import "mime/multipart"
+import (
+	"context"
+	"mime/multipart"
+)
 
 // IBlobUploadService defines methods for uploading blobs.
 type IBlobUploadService interface {
 	// Upload transfers blobs with the option to encrypt them using an encryption key or sign them with a signing key.
 	// It returns a slice of Blob for the uploaded blobs and any error encountered during the upload process.
-	Upload(form *multipart.Form, userId string, encryptionKeyId, signKeyId *string) ([]*BlobMeta, error)
+	Upload(ctx context.Context, form *multipart.Form, userId string, encryptionKeyId, signKeyId *string) ([]*BlobMeta, error)
 }
 
 // IBlobMetadataService defines methods for retrieving Blob and deleting a blob along with its metadata.
@@ -21,7 +24,7 @@ type IBlobMetadataService interface {
 
 	// DeleteByID deletes a blob and its associated metadata by ID.
 	// It returns any error encountered during the deletion process.
-	DeleteByID(blobId string) error
+	DeleteByID(ctx context.Context, blobId string) error
 }
 
 // IBlobDownloadService defines methods for downloading blobs.
@@ -29,7 +32,7 @@ type IBlobDownloadService interface {
 	// The download function retrieves a blob's content using its ID and also enables data decryption.
 	// NOTE: Signing should be performed locally by first downloading the associated key, followed by verification.
 	// Optionally, a verify endpoint will be available soon for optional use.
-	Download(blobId string, decryptionKeyId *string) ([]byte, error)
+	Download(ctx context.Context, blobId string, decryptionKeyId *string) ([]byte, error)
 }
 
 // BlobRepository defines the interface for Blob-related operations

--- a/internal/domain/keys/contracts.go
+++ b/internal/domain/keys/contracts.go
@@ -1,10 +1,12 @@
 package keys
 
+import "context"
+
 // ICryptoKeyUploadService defines methods for uploading cryptographic keys.
 type ICryptoKeyUploadService interface {
 	// Upload uploads cryptographic keys
 	// It returns a slice of CryptoKeyMeta and any error encountered during the upload process.
-	Upload(userId, keyPairId, keyAlgorihm string, keySize uint) ([]*CryptoKeyMeta, error)
+	Upload(ctx context.Context, userId, keyPairId, keyAlgorihm string, keySize uint) ([]*CryptoKeyMeta, error)
 }
 
 // ICryptoKeyMetadataService defines methods for managing cryptographic key metadata and deleting keys.
@@ -19,14 +21,14 @@ type ICryptoKeyMetadataService interface {
 
 	// DeleteByID deletes a cryptographic key and its associated metadata by ID.
 	// It returns any error encountered during the deletion process.
-	DeleteByID(keyID string) error
+	DeleteByID(ctx context.Context, keyID string) error
 }
 
 // ICryptoKeyDownloadService defines methods for downloading cryptographic keys.
 type ICryptoKeyDownloadService interface {
 	// Download retrieves a cryptographic key by its ID
 	// It returns the CryptoKeyMeta, the key data as a byte slice, and any error encountered during the download process.
-	Download(keyID string) ([]byte, error)
+	Download(ctx context.Context, keyID string) ([]byte, error)
 }
 
 // CryptoKeyRepository defines the interface for CryptoKey-related operations

--- a/internal/infrastructure/connector/key_connectors.go
+++ b/internal/infrastructure/connector/key_connectors.go
@@ -19,16 +19,15 @@ import (
 type VaultConnector interface {
 	// Upload uploads bytes of a single file to Blob Storage
 	// and returns the metadata for each uploaded byte stream.
-	Upload(bytes []byte, userId, keyPairId, keyType, keyAlgorihm string, keySize uint) (*keys.CryptoKeyMeta, error)
+	Upload(ctx context.Context, bytes []byte, userId, keyPairId, keyType, keyAlgorihm string, keySize uint) (*keys.CryptoKeyMeta, error)
 
 	// Download retrieves a key's content by its IDs and type and returns the data as a byte slice.
-	Download(keyId, keyPairId, keyType string) ([]byte, error)
+	Download(ctx context.Context, keyId, keyPairId, keyType string) ([]byte, error)
 
 	// Delete deletes a key from Vault Storage by its IDs and type and returns any error encountered.
-	Delete(keyId, keyPairId, keyType string) error
+	Delete(ctx context.Context, keyId, keyPairId, keyType string) error
 }
 
-// AzureVaultConnector is a struct that implements the VaultConnector interface using Azure Blob Storage.
 // This is a temporary implementation and may later be replaced with more specialized external key management systems
 // like Azure Key Vault or AWS KMS.
 type AzureVaultConnector struct {
@@ -39,7 +38,7 @@ type AzureVaultConnector struct {
 
 // NewAzureVaultConnector creates a new instance of AzureVaultConnector, which connects to Azure Blob Storage.
 // This method can be updated in the future to support a more sophisticated key management system like Azure Key Vault.
-func NewAzureVaultConnector(settings *settings.KeyConnectorSettings, logger logger.Logger) (*AzureVaultConnector, error) {
+func NewAzureVaultConnector(ctx context.Context, settings *settings.KeyConnectorSettings, logger logger.Logger) (*AzureVaultConnector, error) {
 	if err := settings.Validate(); err != nil {
 		return nil, err
 	}
@@ -49,7 +48,7 @@ func NewAzureVaultConnector(settings *settings.KeyConnectorSettings, logger logg
 		return nil, fmt.Errorf("failed to create Azure Blob client: %w", err)
 	}
 
-	_, _ = client.CreateContainer(context.Background(), settings.ContainerName, nil)
+	_, _ = client.CreateContainer(ctx, settings.ContainerName, nil)
 	// if err != nil {
 	// 	log.Printf("Failed to create Azure container: %v\n", err)
 	// }
@@ -63,7 +62,7 @@ func NewAzureVaultConnector(settings *settings.KeyConnectorSettings, logger logg
 
 // Upload uploads bytes of a single file to Blob Storage
 // and returns the metadata for each uploaded byte stream.
-func (vc *AzureVaultConnector) Upload(bytes []byte, userId, keyPairId, keyType, keyAlgorihm string, keySize uint) (*keys.CryptoKeyMeta, error) {
+func (vc *AzureVaultConnector) Upload(ctx context.Context, bytes []byte, userId, keyPairId, keyType, keyAlgorihm string, keySize uint) (*keys.CryptoKeyMeta, error) {
 	keyId := uuid.New().String()
 	fullKeyName := fmt.Sprintf("%s/%s-%s", keyPairId, keyId, keyType)
 
@@ -77,9 +76,9 @@ func (vc *AzureVaultConnector) Upload(bytes []byte, userId, keyPairId, keyType, 
 		UserID:          userId,
 	}
 
-	_, err := vc.client.UploadBuffer(context.Background(), vc.containerName, fullKeyName, bytes, nil)
+	_, err := vc.client.UploadBuffer(ctx, vc.containerName, fullKeyName, bytes, nil)
 	if err != nil {
-		vc.rollbackUploadedBlobs(cryptoKeyMeta)
+		vc.rollbackUploadedBlobs(ctx, cryptoKeyMeta)
 		return nil, fmt.Errorf("failed to upload blob '%s' to storage: %w", fullKeyName, err)
 	}
 
@@ -88,8 +87,8 @@ func (vc *AzureVaultConnector) Upload(bytes []byte, userId, keyPairId, keyType, 
 }
 
 // rollbackUploadedBlobs deletes the blobs that were uploaded successfully before the error occurred
-func (vc *AzureVaultConnector) rollbackUploadedBlobs(cryptoKeyMeta *keys.CryptoKeyMeta) {
-	err := vc.Delete(cryptoKeyMeta.ID, cryptoKeyMeta.KeyPairID, cryptoKeyMeta.Type)
+func (vc *AzureVaultConnector) rollbackUploadedBlobs(ctx context.Context, cryptoKeyMeta *keys.CryptoKeyMeta) {
+	err := vc.Delete(ctx, cryptoKeyMeta.ID, cryptoKeyMeta.KeyPairID, cryptoKeyMeta.Type)
 	if err != nil {
 		vc.logger.Info(fmt.Sprintf("Failed to delete key '%s' during rollback: %v", cryptoKeyMeta.ID, err))
 	} else {
@@ -98,11 +97,10 @@ func (vc *AzureVaultConnector) rollbackUploadedBlobs(cryptoKeyMeta *keys.CryptoK
 }
 
 // Download retrieves a key's content by its IDs and Type and returns the data as a byte slice.
-func (vc *AzureVaultConnector) Download(keyId, keyPairId, keyType string) ([]byte, error) {
+func (vc *AzureVaultConnector) Download(ctx context.Context, keyId, keyPairId, keyType string) ([]byte, error) {
 
 	fullKeyName := fmt.Sprintf("%s/%s-%s", keyPairId, keyId, keyType)
 
-	ctx := context.Background()
 	get, err := vc.client.DownloadStream(ctx, vc.containerName, fullKeyName, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download blob '%s': %w", fullKeyName, err)
@@ -119,10 +117,9 @@ func (vc *AzureVaultConnector) Download(keyId, keyPairId, keyType string) ([]byt
 }
 
 // Delete deletes a key from Azure Blob Storage by its IDs and Type.
-func (vc *AzureVaultConnector) Delete(keyId, keyPairId, keyType string) error {
+func (vc *AzureVaultConnector) Delete(ctx context.Context, keyId, keyPairId, keyType string) error {
 	fullKeyName := fmt.Sprintf("%s/%s-%s", keyPairId, keyId, keyType)
 
-	ctx := context.Background()
 	_, err := vc.client.DeleteBlob(ctx, vc.containerName, fullKeyName, nil)
 	if err != nil {
 		return fmt.Errorf("failed to delete blob '%s': %w", fullKeyName, err)

--- a/test/integration/infrastructure/connector/az_blob_connector_test.go
+++ b/test/integration/infrastructure/connector/az_blob_connector_test.go
@@ -1,6 +1,7 @@
 package connector
 
 import (
+	"context"
 	"testing"
 
 	"crypto_vault_service/internal/infrastructure/connector"
@@ -33,7 +34,8 @@ func NewAzureBlobConnectorTest(t *testing.T, cloudProvider, connectionString str
 		ContainerName:    containerName,
 	}
 
-	blobConnector, err := connector.NewAzureBlobConnector(blobConnectorSettings, logger)
+	ctx := context.Background()
+	blobConnector, err := connector.NewAzureBlobConnector(ctx, blobConnectorSettings, logger)
 	require.NoError(t, err)
 
 	return &AzureBlobConnectorTest{
@@ -54,7 +56,9 @@ func TestAzureBlobConnector_Upload(t *testing.T) {
 
 	var encryptionKeyId *string = nil
 	var signKeyId *string = nil
-	blobs, err := abct.BlobConnector.Upload(form, userId, encryptionKeyId, signKeyId)
+	ctx := context.Background()
+
+	blobs, err := abct.BlobConnector.Upload(ctx, form, userId, encryptionKeyId, signKeyId)
 	require.NoError(t, err)
 
 	require.Len(t, blobs, 1)
@@ -64,7 +68,7 @@ func TestAzureBlobConnector_Upload(t *testing.T) {
 	assert.Equal(t, int64(len(testFileContent)), blob.Size)
 	assert.Equal(t, ".txt", blob.Type)
 
-	err = abct.BlobConnector.Delete(blob.ID, blob.Name)
+	err = abct.BlobConnector.Delete(ctx, blob.ID, blob.Name)
 	require.NoError(t, err)
 }
 
@@ -81,17 +85,18 @@ func TestAzureBlobConnector_Download(t *testing.T) {
 
 	var encryptionKeyId *string = nil
 	var signKeyId *string = nil
-	blobs, err := abct.BlobConnector.Upload(form, userId, encryptionKeyId, signKeyId)
+	ctx := context.Background()
+	blobs, err := abct.BlobConnector.Upload(ctx, form, userId, encryptionKeyId, signKeyId)
 	require.NoError(t, err)
 
 	blob := blobs[0]
 
-	downloadedData, err := abct.BlobConnector.Download(blob.ID, blob.Name)
+	downloadedData, err := abct.BlobConnector.Download(ctx, blob.ID, blob.Name)
 	require.NoError(t, err)
 
 	assert.Equal(t, testFileContent, downloadedData)
 
-	err = abct.BlobConnector.Delete(blob.ID, blob.Name)
+	err = abct.BlobConnector.Delete(ctx, blob.ID, blob.Name)
 	require.NoError(t, err)
 }
 
@@ -108,14 +113,16 @@ func TestAzureBlobConnector_Delete(t *testing.T) {
 
 	var encryptionKeyId *string = nil
 	var signKeyId *string = nil
-	blobs, err := abct.BlobConnector.Upload(form, userId, encryptionKeyId, signKeyId)
+	ctx := context.Background()
+
+	blobs, err := abct.BlobConnector.Upload(ctx, form, userId, encryptionKeyId, signKeyId)
 	require.NoError(t, err)
 
 	blob := blobs[0]
 
-	err = abct.BlobConnector.Delete(blob.ID, blob.Name)
+	err = abct.BlobConnector.Delete(ctx, blob.ID, blob.Name)
 	require.NoError(t, err)
 
-	_, err = abct.BlobConnector.Download(blob.ID, blob.Name)
+	_, err = abct.BlobConnector.Download(ctx, blob.ID, blob.Name)
 	assert.Error(t, err)
 }

--- a/test/integration/infrastructure/connector/az_vault_connector_test.go
+++ b/test/integration/infrastructure/connector/az_vault_connector_test.go
@@ -1,6 +1,7 @@
 package connector
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -34,7 +35,10 @@ func NewAzureVaultConnectorTest(t *testing.T, cloudProvider, connectionString, c
 		ConnectionString: connectionString,
 		ContainerName:    containerName,
 	}
-	abc, err := connector.NewAzureVaultConnector(keyConnectorSettings, logger)
+
+	ctx := context.Background()
+
+	abc, err := connector.NewAzureVaultConnector(ctx, keyConnectorSettings, logger)
 	require.NoError(t, err)
 
 	return &AzureVaultConnectorTest{
@@ -52,8 +56,9 @@ func TestAzureVaultConnector_Upload(t *testing.T) {
 	keyAlgorithm := "RSA"
 	keyType := "private"
 	keySize := 2048
+	ctx := context.Background()
 
-	cryptoKeyMeta, err := helper.Connector.Upload(testFileContent, userId, keyPairId, keyType, keyAlgorithm, uint(keySize))
+	cryptoKeyMeta, err := helper.Connector.Upload(ctx, testFileContent, userId, keyPairId, keyType, keyAlgorithm, uint(keySize))
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, cryptoKeyMeta.ID)
@@ -61,7 +66,7 @@ func TestAzureVaultConnector_Upload(t *testing.T) {
 	assert.Equal(t, userId, cryptoKeyMeta.UserID)
 	assert.WithinDuration(t, time.Now(), cryptoKeyMeta.DateTimeCreated, time.Second)
 
-	err = helper.Connector.Delete(cryptoKeyMeta.ID, cryptoKeyMeta.KeyPairID, cryptoKeyMeta.Type)
+	err = helper.Connector.Delete(ctx, cryptoKeyMeta.ID, cryptoKeyMeta.KeyPairID, cryptoKeyMeta.Type)
 	require.NoError(t, err)
 }
 
@@ -75,16 +80,17 @@ func TestAzureVaultConnector_Download(t *testing.T) {
 	keyAlgorithm := "RSA"
 	keyType := "private"
 	keySize := 2048
+	ctx := context.Background()
 
-	cryptoKeyMeta, err := helper.Connector.Upload(testFileContent, userId, keyPairId, keyType, keyAlgorithm, uint(keySize))
+	cryptoKeyMeta, err := helper.Connector.Upload(ctx, testFileContent, userId, keyPairId, keyType, keyAlgorithm, uint(keySize))
 	require.NoError(t, err)
 
-	downloadedData, err := helper.Connector.Download(cryptoKeyMeta.ID, cryptoKeyMeta.KeyPairID, cryptoKeyMeta.Type)
+	downloadedData, err := helper.Connector.Download(ctx, cryptoKeyMeta.ID, cryptoKeyMeta.KeyPairID, cryptoKeyMeta.Type)
 	require.NoError(t, err)
 
 	assert.Equal(t, testFileContent, downloadedData)
 
-	err = helper.Connector.Delete(cryptoKeyMeta.ID, cryptoKeyMeta.KeyPairID, cryptoKeyMeta.Type)
+	err = helper.Connector.Delete(ctx, cryptoKeyMeta.ID, cryptoKeyMeta.KeyPairID, cryptoKeyMeta.Type)
 	require.NoError(t, err)
 }
 
@@ -98,13 +104,14 @@ func TestAzureVaultConnector_Delete(t *testing.T) {
 	keyAlgorithm := "RSA"
 	keyType := "private"
 	keySize := 2048
+	ctx := context.Background()
 
-	cryptoKeyMeta, err := helper.Connector.Upload(testFileContent, userId, keyPairId, keyType, keyAlgorithm, uint(keySize))
+	cryptoKeyMeta, err := helper.Connector.Upload(ctx, testFileContent, userId, keyPairId, keyType, keyAlgorithm, uint(keySize))
 	require.NoError(t, err)
 
-	err = helper.Connector.Delete(cryptoKeyMeta.ID, cryptoKeyMeta.KeyPairID, cryptoKeyMeta.Type)
+	err = helper.Connector.Delete(ctx, cryptoKeyMeta.ID, cryptoKeyMeta.KeyPairID, cryptoKeyMeta.Type)
 	require.NoError(t, err)
 
-	_, err = helper.Connector.Download(cryptoKeyMeta.ID, cryptoKeyMeta.KeyPairID, cryptoKeyMeta.Type)
+	_, err = helper.Connector.Download(ctx, cryptoKeyMeta.ID, cryptoKeyMeta.KeyPairID, cryptoKeyMeta.Type)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
# Checklist
- [x] I adhere the [trunk-based workflow](https://www.atlassian.com/continuous-delivery/continuous-integration/trunk-based-development)
- [ ] I verify that the `CHANGELOG.md` includes comprehensive documentation for the implemented features or fixed bugs. Increment the minor version such as `from 0.1.0 to 0.2.0` for implemented features and increment the patch version `from 0.1.0 to 0.1.1` for bug fixes. If any breaking changes occur, increment the major version, like `from 0.1.0 to 1.0.0`. Also see [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
- [x] I ensure that all merge conflicts are resolved before asking for a PR reviewer
- [x] To ensure the success of all pull request workflows, I run the [format-and-lint.sh](../scripts/format-and-lint.sh) and [run-test.sh](../scripts/run-test.sh) locally.

# Reference/Link to the issue solved with this PR (if any)

### Updated

- Considered passing context as an input argument to manage concurrent operations (control cancellation, set timeouts/deadlines, propagate values).